### PR TITLE
Potential fix for code scanning alert no. 11: Server-side request forgery

### DIFF
--- a/client/pages/plugins/[plugin_id].tsx
+++ b/client/pages/plugins/[plugin_id].tsx
@@ -36,11 +36,15 @@ export default function PluginDetails() {
   /** Use Next router to get conversation_id */
   const router = useRouter();
   const { plugin_id } = router.query;
+  const VALID_PLUGIN_IDS = ["plugin1", "plugin2", "plugin3"]; // Example allow-list
   const existingPluginIndex = getPluginIndex();
 
   useEffect(() => {
-    if (plugin_id) {
+    if (plugin_id && VALID_PLUGIN_IDS.includes(plugin_id)) {
       loadPluginDetails();
+    } else {
+      console.log("Invalid plugin_id:", plugin_id);
+      return;
     }
 
     async function loadPluginDetails() {


### PR DESCRIPTION
Potential fix for [https://github.com/jhead12/web3db-connector/security/code-scanning/11](https://github.com/jhead12/web3db-connector/security/code-scanning/11)

To fix the issue, we need to validate and sanitize the `plugin_id` before using it in the `fetch` call. The best approach is to enforce a strict allow-list of acceptable `plugin_id` values. This ensures that only known and valid `plugin_id` values are used in the request.

1. Define an allow-list of valid `plugin_id` values (e.g., as a constant or fetched from a trusted source).
2. Before making the `fetch` call, check if the `plugin_id` exists in the allow-list.
3. If the `plugin_id` is invalid, handle the error gracefully (e.g., log the error and show an appropriate message to the user).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
